### PR TITLE
[FIX] cast variable types to comply strict_types

### DIFF
--- a/Classes/ViewHelpers/SvgViewHelper.php
+++ b/Classes/ViewHelpers/SvgViewHelper.php
@@ -84,20 +84,32 @@ class SvgViewHelper extends AbstractTagBasedViewHelper
         if ($this->arguments['title']) {
             $titleId = sprintf('title-%s', $uniqueId);
             $ariaLabelledBy[] = $titleId;
-            $content[] = sprintf('<title id="%s">%s</title>', $titleId, htmlspecialchars($this->arguments['title']));
+            $content[] = sprintf(
+                '<title id="%s">%s</title>',
+                $titleId,
+                htmlspecialchars((string)$this->arguments['title'], ENT_QUOTES | ENT_HTML5)
+            );
         }
 
         if ($this->arguments['description']) {
             $descriptionId = sprintf('description-%s', $uniqueId);
             $ariaLabelledBy[] = $descriptionId;
-            $content[] = sprintf('<desc id="%s">%s</desc>', $descriptionId, htmlspecialchars($this->arguments['description']));
+            $content[] = sprintf(
+                '<desc id="%s">%s</desc>',
+                $descriptionId,
+                htmlspecialchars((string)$this->arguments['description'], ENT_QUOTES | ENT_HTML5)
+            );
         }
 
         if (! empty($ariaLabelledBy)) {
             $this->tag->addAttribute('aria-labelledby', implode(' ', $ariaLabelledBy));
         }
 
-        $content[] = sprintf('<use xlink:href="%s#%s" />', $imageUri, htmlspecialchars($this->arguments['name']));
+        $content[] = sprintf(
+            '<use xlink:href="%s#%s" />',
+            $imageUri,
+            htmlspecialchars((string)$this->arguments['name'], ENT_QUOTES | ENT_HTML5)
+        );
 
         $this->tag->setContent(implode('', $content));
 

--- a/Tests/Unit/ViewHelpers/SvgViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SvgViewHelperTest.php
@@ -73,7 +73,7 @@ class SvgViewHelperTest extends ViewHelperBaseTestcase
      */
     public function render(array $arguments, string $expected)
     {
-        $arguments = array_merge($arguments, ['src' => 'somefile.jpg', 'name' => 'name']);
+        $arguments = array_merge($arguments, ['src' => 'somefile.svg']);
         $image = $this->getMockBuilder(FileInterface::class)->getMock();
         $this->viewHelper->setArguments($arguments);
         $this->imageService->expects($this->once())->method('getImage')->with($arguments['src'])->willReturn($image);
@@ -84,11 +84,19 @@ class SvgViewHelperTest extends ViewHelperBaseTestcase
     {
         return [
             [
-                [],
-                '<svg xmlns="http://www.w3.org/2000/svg" focusable="false"><use xlink:href="#name" /></svg>'
+                ['name' => 'name'],
+                sprintf('<svg xmlns="http://www.w3.org/2000/svg" focusable="false"><use xlink:href="#name" /></svg>')
             ],
             [
-                ['title' => 'Title', 'description' => 'Description'],
+                ['name' => 1420],
+                '<svg xmlns="http://www.w3.org/2000/svg" focusable="false"><use xlink:href="#1420" /></svg>'
+            ],
+            [
+                ['name' => 3333, 'title' => 1222, 'description' => 1420],
+                sprintf('<svg aria-labelledby="title-%1$s description-%1$s" xmlns="http://www.w3.org/2000/svg" focusable="false"><title id="title-%1$s">1222</title><desc id="description-%1$s">1420</desc><use xlink:href="#3333" /></svg>', self::ID)
+            ],
+            [
+                ['name' => 'name', 'title' => 'Title', 'description' => 'Description'],
                 sprintf('<svg aria-labelledby="title-%1$s description-%1$s" xmlns="http://www.w3.org/2000/svg" focusable="false"><title id="title-%1$s">Title</title><desc id="description-%1$s">Description</desc><use xlink:href="#name" /></svg>', self::ID)
             ],
         ];


### PR DESCRIPTION
additionally force ENT_QUOTE and ENT_HTML5

ENT_COMPAT might be enough to convert double quotes.
But single quotes still do not look nice when used in html tag-attributes.