### PR TITLE
[FEATURE] add ability to inline sprite symbols

### DIFF
--- a/Classes/ViewHelpers/SvgViewHelper.php
+++ b/Classes/ViewHelpers/SvgViewHelper.php
@@ -1,5 +1,5 @@
 <?php
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Ssch\Typo3Encore\ViewHelpers;
 
@@ -16,6 +16,9 @@ namespace Ssch\Typo3Encore\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
+use DOMDocument;
+use DOMNode;
+use DOMXPath;
 use Ssch\Typo3Encore\Integration\IdGeneratorInterface;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
@@ -62,6 +65,7 @@ class SvgViewHelper extends AbstractTagBasedViewHelper
         $this->registerArgument('src', 'string', 'Path to the svg file', true);
         $this->registerArgument('role', 'string', 'Role', false, 'img');
         $this->registerArgument('name', 'string', 'The icon name of the sprite', true);
+        $this->registerArgument('inline', 'string', 'Inline icon instead of referencing it', false, false);
         $this->registerTagAttribute('description', 'string', 'Description text of element');
         $this->registerArgument('width', 'string', 'Width of the image.');
         $this->registerArgument('height', 'string', 'Height of the image.');
@@ -101,15 +105,30 @@ class SvgViewHelper extends AbstractTagBasedViewHelper
             );
         }
 
-        if (! empty($ariaLabelledBy)) {
+        if (!empty($ariaLabelledBy)) {
             $this->tag->addAttribute('aria-labelledby', implode(' ', $ariaLabelledBy));
         }
 
-        $content[] = sprintf(
-            '<use xlink:href="%s#%s" />',
-            $imageUri,
-            htmlspecialchars((string)$this->arguments['name'], ENT_QUOTES | ENT_HTML5)
-        );
+        $name = (string)$this->arguments['name'];
+        if ((bool)$this->arguments['inline']) {
+            $doc = new DOMDocument();
+            $doc->loadXML($image->getContents());
+            $xpath = new DOMXPath($doc);
+            if (($icon = $xpath->query("//*[@id='{$name}']")->item(0)) !== null) {
+                if ($icon->hasAttribute('viewBox')) {
+                    $this->tag->addAttribute('viewBox', $icon->getAttribute('viewBox'));
+                }
+                foreach ($icon->childNodes as $node) {
+                    $content[] = $node->ownerDocument->saveXML($node);
+                }
+            }
+        } else {
+            $content[] = sprintf(
+                '<use xlink:href="%s#%s" />',
+                $imageUri,
+                htmlspecialchars($name, ENT_QUOTES | ENT_HTML5)
+            );
+        }
 
         $this->tag->setContent(implode('', $content));
 

--- a/Tests/Unit/ViewHelpers/SvgViewHelperTest.php
+++ b/Tests/Unit/ViewHelpers/SvgViewHelperTest.php
@@ -75,6 +75,7 @@ final class SvgViewHelperTest extends ViewHelperBaseTestcase
     {
         $arguments = array_merge($arguments, ['src' => 'somefile.svg']);
         $image = $this->getMockBuilder(FileInterface::class)->getMock();
+        $image->method('getContents')->willReturn($this->getMockSvg());
         $this->viewHelper->setArguments($arguments);
         $this->imageService->expects($this->once())->method('getImage')->with($arguments['src'])->willReturn($image);
         $this->assertEquals($expected, $this->viewHelper->render());
@@ -99,6 +100,22 @@ final class SvgViewHelperTest extends ViewHelperBaseTestcase
                 ['name' => 'name', 'title' => 'Title', 'description' => 'Description', 'width' => 100, 'height' => 100, 'role' => 'foo'],
                 sprintf('<svg aria-labelledby="title-%1$s description-%1$s" width="100" height="100" xmlns="http://www.w3.org/2000/svg" focusable="false" role="foo"><title id="title-%1$s">Title</title><desc id="description-%1$s">Description</desc><use xlink:href="#name" /></svg>', self::ID)
             ],
+            [
+                ['name' => 'foobar', 'title' => 'Title', 'description' => 'Description', 'width' => 100, 'height' => 100, 'inline' => true],
+                sprintf('<svg aria-labelledby="title-%1$s description-%1$s" viewBox="0 0 45 45" width="100" height="100" xmlns="http://www.w3.org/2000/svg" focusable="false"><title id="title-%1$s">Title</title><desc id="description-%1$s">Description</desc><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"/></svg>', self::ID)
+            ],
+            [
+                ['name' => 'id-invalid', 'title' => 'Title', 'description' => 'Description', 'width' => 100, 'height' => 100, 'inline' => true],
+                sprintf('<svg aria-labelledby="title-%1$s description-%1$s" width="100" height="100" xmlns="http://www.w3.org/2000/svg" focusable="false"><title id="title-%1$s">Title</title><desc id="description-%1$s">Description</desc></svg>', self::ID)
+            ],
         ];
+    }
+
+    /**
+     * @return string
+     */
+    private function getMockSvg(): string
+    {
+        return '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><defs><symbol viewBox="0 0 45 45" id="foobar"><circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"/></symbol></defs><use id="foobar-usage" xlink:href="#foobar" class="sprite-symbol-usage"/></svg>';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "php": ">=7.2.0 <8.0",
     "typo3/cms-core": "^9.5 || ^10.4",
     "symfony/web-link": "^4.3",
-    "symfony/asset": "^5.0"
+    "symfony/asset": "^5.0",
+    "ext-dom": "*"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.0",


### PR DESCRIPTION
This commit introduces a new argument "inline" for the SvgViewHelper.
If enabled, sprite symbols are inlined instead of referenced via `<use>`.