### PR TITLE
[BUGFIX] Add link header for cached pages

### DIFF
--- a/Classes/Integration/TypoScriptFrontendControllerHooks.php
+++ b/Classes/Integration/TypoScriptFrontendControllerHooks.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types = 1);
+
+namespace Ssch\Typo3Encore\Integration;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+final class TypoScriptFrontendControllerHooks
+{
+    /**
+     * @var TypoScriptFrontendController
+     */
+    protected $controller;
+
+    /**
+     * @var AssetRegistryInterface
+     */
+    private $assetRegistry;
+
+    /**
+     * @var SettingsServiceInterface
+     */
+    private $settingsService;
+
+    public function __construct(TypoScriptFrontendController $controller = null, AssetRegistryInterface $assetRegistry = null, SettingsServiceInterface $settingsService = null)
+    {
+        $this->controller = $controller ?? $GLOBALS['TSFE'];
+
+        if (! $assetRegistry instanceof AssetRegistryInterface) {
+            // @codeCoverageIgnoreStart
+            /** @var AssetRegistryInterface $assetRegistry */
+            $assetRegistry = GeneralUtility::makeInstance(ObjectManager::class)->get(AssetRegistryInterface::class);
+            // @codeCoverageIgnoreEnd
+        }
+
+        if (! $settingsService instanceof SettingsServiceInterface) {
+            // @codeCoverageIgnoreStart
+            /** @var SettingsServiceInterface $settingsService */
+            $settingsService = GeneralUtility::makeInstance(ObjectManager::class)->get(SettingsServiceInterface::class);
+            // @codeCoverageIgnoreEnd
+        }
+
+        $this->settingsService = $settingsService;
+        $this->assetRegistry = $assetRegistry;
+    }
+
+    public function contentPostProcAll(array $params, TypoScriptFrontendController $tsfe)
+    {
+        if (! $this->assetRegistry->getRegisteredFiles()) {
+            return;
+        }
+
+        $this->controller->config['encore_asset_registry'] = [
+            'registered_files' => $this->assetRegistry->getRegisteredFiles(),
+            'default_attributes' => $this->assetRegistry->getDefaultAttributes(),
+            'settings' => $this->settingsService->getSettings(),
+        ];
+    }
+}

--- a/Tests/Unit/Integration/TypoScriptFrontendControllerHooksTest.php
+++ b/Tests/Unit/Integration/TypoScriptFrontendControllerHooksTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Ssch\Typo3Encore\Tests\Unit\Integration;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use PHPUnit\Framework\MockObject\MockObject;
+use Ssch\Typo3Encore\Integration\AssetRegistryInterface;
+use Ssch\Typo3Encore\Integration\SettingsServiceInterface;
+use Ssch\Typo3Encore\Integration\TypoScriptFrontendControllerHooks;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+
+/**
+ * @covers \Ssch\Typo3Encore\Integration\TypoScriptFrontendControllerHooks
+ */
+final class TypoScriptFrontendControllerHooksTest extends UnitTestCase
+{
+    /**
+     * @var TypoScriptFrontendControllerHooks
+     */
+    protected $subject;
+
+    /**
+     * @var MockObject|TypoScriptFrontendController
+     */
+    private $typoScriptFrontendController;
+
+    /**
+     * @var MockObject|SettingsServiceInterface
+     */
+    private $settingsService;
+
+    /**
+     * @var AssetRegistryInterface|MockObject
+     */
+    private $assetRegistry;
+
+    protected function setUp()
+    {
+        $this->typoScriptFrontendController = $this->getMockBuilder(TypoScriptFrontendController::class)->disableOriginalConstructor()->getMock();
+        $this->settingsService = $this->getMockBuilder(SettingsServiceInterface::class)->getMock();
+        $this->assetRegistry = $this->getMockBuilder(AssetRegistryInterface::class)->getMock();
+        $this->subject = new TypoScriptFrontendControllerHooks($this->typoScriptFrontendController, $this->assetRegistry, $this->settingsService);
+    }
+
+    /**
+     * @test
+     */
+    public function registryDoesNotContainFiles()
+    {
+        $this->assetRegistry->expects($this->once())->method('getRegisteredFiles')->willReturn([]);
+        $this->assetRegistry->expects($this->never())->method('getDefaultAttributes');
+        $this->settingsService->expects($this->never())->method('getSettings');
+        $this->subject->contentPostProcAll([], $this->typoScriptFrontendController);
+
+        $this->assertArrayNotHasKey('encore_asset_registry', $this->typoScriptFrontendController->config);
+    }
+
+    /**
+     * @test
+     */
+    public function registryContainsFiles()
+    {
+        $registeredFiles = [
+            'preload' => [
+                'files' => [
+                    'style' => [
+                        'file1.css' => [
+                            'crossorigin' => true,
+                        ],
+                        'script' => [
+                            'file2.js' => [
+                                'crossorigin' => true,
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $defaultAttributes = ['crossorigin' => true];
+        $settings = [
+            'preload' => [
+                'enable' => true,
+            ],
+        ];
+
+        $this->assetRegistry->expects($this->exactly(2))->method('getRegisteredFiles')->willReturn($registeredFiles);
+        $this->assetRegistry->expects($this->once())->method('getDefaultAttributes')->willReturn($defaultAttributes);
+        $this->settingsService->expects($this->once())->method('getSettings')->willReturn($settings);
+        $this->subject->contentPostProcAll([], $this->typoScriptFrontendController);
+
+        $this->assertArrayHasKey('encore_asset_registry', $this->typoScriptFrontendController->config);
+        $this->assertSame($registeredFiles, $this->typoScriptFrontendController->config['encore_asset_registry']['registered_files']);
+        $this->assertSame($defaultAttributes, $this->typoScriptFrontendController->config['encore_asset_registry']['default_attributes']);
+        $this->assertSame($settings, $this->typoScriptFrontendController->config['encore_asset_registry']['settings']);
+    }
+}

--- a/Tests/Unit/Middleware/AssetsMiddlewareTest.php
+++ b/Tests/Unit/Middleware/AssetsMiddlewareTest.php
@@ -87,7 +87,7 @@ final class AssetsMiddlewareTest extends UnitTestCase
         $handler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
         $response = new Response();
         $handler->method('handle')->willReturn($response);
-        $this->settingsService->expects($this->once())->method('getBooleanByPath')->willReturn(false);
+        $this->settingsService->expects($this->once())->method('getSettings')->willReturn([]);
         $this->assetRegistry->method('getRegisteredFiles')->willReturn($registeredFiles);
         $defaultAttributes = ['crossorigin' => true];
         $this->assetRegistry->expects($this->once())->method('getDefaultAttributes')->willReturn($defaultAttributes);
@@ -176,6 +176,7 @@ final class AssetsMiddlewareTest extends UnitTestCase
         $handler = $this->getMockBuilder(RequestHandlerInterface::class)->getMock();
         $response = new Response();
         $handler->method('handle')->willReturn($response);
+        $this->settingsService->method('getSettings')->willReturn(['array' => 'should-not-be-empty']);
         $this->settingsService->method('getBooleanByPath')->willReturn(true);
         $this->assetRegistry->method('getRegisteredFiles')->willReturn($registeredFiles);
         $defaultAttributes = ['crossorigin' => true];

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -25,6 +25,8 @@ call_user_func(static function ($packageKey) {
 
     // Enable for Frontend and Backend at the same time
     $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_pagerenderer.php']['render-preProcess'][$packageKey] = \Ssch\Typo3Encore\Integration\PageRendererHooks::class . '->renderPreProcess';
+    // Add collected assets to page cache
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['contentPostProc-all'][$packageKey] =  \Ssch\Typo3Encore\Integration\TypoScriptFrontendControllerHooks::class . '->contentPostProcAll';
 }, 'typo3_encore');
 
 if (!\TYPO3\CMS\Core\Core\Environment::isComposerMode()) {


### PR DESCRIPTION
The link header will collect the required assets from the page cache if page is generated from cache. The required data is stored in the $tsfe->config array using the contentPostProc-all hook.

Solves #42 