### PR TITLE
TagRenderer now renders the JS files in the correct place, where they are specified in TypoScript

### DIFF
--- a/Classes/Asset/TagRenderer.php
+++ b/Classes/Asset/TagRenderer.php
@@ -49,7 +49,7 @@ final class TagRenderer implements TagRendererInterface
 
         unset($parameters['file']);
         foreach ($files as $file) {
-            $attributes = [
+            $attributes = array_replace([
                 'file' => $file,
                 'type' => 'text/javascript',
                 'compress' => false,
@@ -61,14 +61,24 @@ final class TagRenderer implements TagRendererInterface
                 'integrity' => $integrityHashes[$file] ?? '',
                 'defer' => false,
                 'crossorigin' => ''
-            ];
+            ], $parameters);
 
-            $attributes = array_values(array_replace($attributes, $parameters));
+            $attributes = array_values($attributes);
 
-            if ($position === 'footer') {
-                $pageRenderer->addJsFooterFile(...$attributes);
-            } else {
-                $pageRenderer->addJsFile(...$attributes);
+            switch ($position) {
+                default:
+                case 'jsFiles':
+                    $pageRenderer->addJsFile(...$attributes);
+                    break;
+                case 'jsLibs':
+                    $pageRenderer->addJsLibrary(...$attributes);
+                    break;
+                case 'jsFooterFiles':
+                    $pageRenderer->addJsFooterFile(...$attributes);
+                    break;
+                case 'jsFooterLibs':
+                    $pageRenderer->addJsFooterLibrary(...$attributes);
+                    break;
             }
 
             if ($registerFile === true) {

--- a/Classes/Integration/PageRendererHooks.php
+++ b/Classes/Integration/PageRendererHooks.php
@@ -51,51 +51,54 @@ final class PageRendererHooks
     public function renderPreProcess(array $params, PageRenderer $pageRenderer): void
     {
         // Add JavaScript Files by entryNames
-        foreach (['jsFiles', 'jsFooterLibs', 'jsLibs'] as $includeType) {
-            if (! empty($params[$includeType])) {
-                foreach ($params[$includeType] as $key => $jsFile) {
-                    if ($this->isEncoreEntryName($jsFile['file'])) {
-                        $buildAndEntryName = $this->createBuildAndEntryName($jsFile['file']);
-                        $buildName = '_default';
+        foreach (['jsFiles', 'jsLibs', 'jsFooterFiles', 'jsFooterLibs'] as $includeType) {
+            if (empty($params[ $includeType ])) {
+                continue;
+            }
 
-                        if (count($buildAndEntryName) === 2) {
-                            [$buildName, $entryName] = $buildAndEntryName;
-                        } else {
-                            $entryName = $buildAndEntryName[0];
-                        }
-
-                        $position = '';
-                        if (array_key_exists('section', $params[$includeType][$key])) {
-                            $position = (int)$params[$includeType][$key]['section'] === PageRenderer::PART_FOOTER ? 'footer' : '';
-                        }
-
-                        unset($params[$includeType][$key], $jsFile['file'], $jsFile['section'], $jsFile['integrity']);
-
-                        $this->tagRenderer->renderWebpackScriptTags($entryName, $position, $buildName, $pageRenderer, $jsFile);
-                    }
+            foreach ($params[ $includeType ] as $key => $jsFile) {
+                if (!$this->isEncoreEntryName($jsFile['file'])) {
+                    continue;
                 }
+
+                $buildAndEntryName = $this->createBuildAndEntryName($jsFile['file']);
+                $buildName = '_default';
+
+                if (count($buildAndEntryName) === 2) {
+                    [ $buildName, $entryName ] = $buildAndEntryName;
+                } else {
+                    $entryName = $buildAndEntryName[0];
+                }
+
+                unset($params[ $includeType ][ $key ], $jsFile['file'], $jsFile['section'], $jsFile['integrity']);
+
+                $this->tagRenderer->renderWebpackScriptTags($entryName, $includeType, $buildName, $pageRenderer, $jsFile);
             }
         }
 
         // Add CSS-Files by entryNames
         foreach (['cssFiles'] as $includeType) {
-            if (! empty($params[$includeType])) {
-                foreach ($params[$includeType] as $key => $cssFile) {
-                    if ($this->isEncoreEntryName($cssFile['file'])) {
-                        $buildAndEntryName = $this->createBuildAndEntryName($cssFile['file']);
-                        $buildName = '_default';
+            if (empty($params[ $includeType ])) {
+                continue;
+            }
 
-                        if (count($buildAndEntryName) === 2) {
-                            [$buildName, $entryName] = $buildAndEntryName;
-                        } else {
-                            $entryName = $buildAndEntryName[0];
-                        }
-
-                        unset($params[$includeType][$key], $cssFile['file']);
-
-                        $this->tagRenderer->renderWebpackLinkTags($entryName, 'all', $buildName, $pageRenderer, $cssFile);
-                    }
+            foreach ($params[ $includeType ] as $key => $cssFile) {
+                if (!$this->isEncoreEntryName($cssFile['file'])) {
+                    continue;
                 }
+
+                $buildAndEntryName = $this->createBuildAndEntryName($cssFile['file']);
+                $buildName = '_default';
+
+                if (count($buildAndEntryName) === 2) {
+                    [ $buildName, $entryName ] = $buildAndEntryName;
+                } else {
+                    $entryName = $buildAndEntryName[0];
+                }
+
+                unset($params[ $includeType ][ $key ], $cssFile['file']);
+
+                $this->tagRenderer->renderWebpackLinkTags($entryName, 'all', $buildName, $pageRenderer, $cssFile);
             }
         }
     }

--- a/Tests/Unit/Asset/TagRendererTest.php
+++ b/Tests/Unit/Asset/TagRendererTest.php
@@ -50,12 +50,29 @@ final class TagRendererTest extends UnitTestCase
      */
     protected $assetRegistry;
 
+    protected $addJsCallArguments = [];
+
     protected function setUp(): void
     {
         $this->pageRenderer = $this->prophesize(PageRenderer::class);
         $this->entryLookupCollection = $this->prophesize(EntrypointLookupCollectionInterface::class);
         $this->assetRegistry = $this->prophesize(AssetRegistryInterface::class);
         $this->subject = new TagRenderer($this->entryLookupCollection->reveal(), $this->assetRegistry->reveal());
+
+        $this->addJsCallArguments = [
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any()
+        ];
     }
 
     /**
@@ -65,7 +82,7 @@ final class TagRendererTest extends UnitTestCase
     {
         $this->entryLookupCollection->getEntrypointLookup('_default')->shouldBeCalledOnce()->willReturn($this->createEntrypointLookUpClass());
 
-        $this->addJsFileShouldBeCalledOnce();
+        $this->pageRenderer->addJsFile(...$this->addJsCallArguments)->shouldBeCalledOnce();
 
         $this->assetRegistry->registerFile(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeCalledOnce();
         $this->subject->renderWebpackScriptTags('app', 'header', '_default', $this->pageRenderer->reveal());
@@ -78,7 +95,7 @@ final class TagRendererTest extends UnitTestCase
     {
         $this->entryLookupCollection->getEntrypointLookup('_default')->shouldBeCalledOnce()->willReturn($this->createEntrypointLookUpClass());
 
-        $this->addJsFileShouldBeCalledOnce();
+        $this->pageRenderer->addJsFile(...$this->addJsCallArguments)->shouldBeCalledOnce();
 
         $this->assetRegistry->registerFile(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $this->subject->renderWebpackScriptTags('app', 'header', '_default', $this->pageRenderer->reveal(), [], false);
@@ -106,7 +123,32 @@ final class TagRendererTest extends UnitTestCase
         )->shouldBeCalledOnce();
 
         $this->assetRegistry->registerFile(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeCalledOnce();
-        $this->subject->renderWebpackScriptTags('app', 'footer', '_default', $this->pageRenderer->reveal(), ['compress' => true, 'excludeFromConcatenation' => false]);
+        $this->subject->renderWebpackScriptTags('app', 'jsFooterFiles', '_default', $this->pageRenderer->reveal(), ['compress' => true, 'excludeFromConcatenation' => false]);
+    }
+
+    /**
+     * @test
+     */
+    public function renderWebpackScriptTagsWithDefaultBuildInFooterLibs(): void
+    {
+        $this->entryLookupCollection->getEntrypointLookup('_default')->shouldBeCalledOnce()->willReturn($this->createEntrypointLookUpClass());
+
+        $this->pageRenderer->addJsFooterLibrary(
+            'file.js',
+            'text/javascript',
+            true,
+            false,
+            '',
+            false,
+            '|',
+            false,
+            'foobarbaz',
+            false,
+            ''
+        )->shouldBeCalledOnce();
+
+        $this->assetRegistry->registerFile(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeCalledOnce();
+        $this->subject->renderWebpackScriptTags('app', 'jsFooterLibs', '_default', $this->pageRenderer->reveal(), ['compress' => true, 'excludeFromConcatenation' => false]);
     }
 
     /**
@@ -155,24 +197,6 @@ final class TagRendererTest extends UnitTestCase
 
         $this->assetRegistry->registerFile(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
         $this->subject->renderWebpackLinkTags('app', 'all', '_default', $this->pageRenderer->reveal(), ['forceOnTop' => true, 'compress' => true], false);
-    }
-
-    private function addJsFileShouldBeCalledOnce(): void
-    {
-        $this->pageRenderer->addJsFile(
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any(),
-            Argument::any()
-        )->shouldBeCalledOnce();
     }
 
     private function createEntrypointLookUpClass(): EntrypointLookupInterface

--- a/Tests/Unit/Integration/PageRendererHooksTest.php
+++ b/Tests/Unit/Integration/PageRendererHooksTest.php
@@ -73,7 +73,7 @@ final class PageRendererHooksTest extends UnitTestCase
             ],
         ];
 
-        $this->tagRenderer->expects($this->once())->method('renderWebpackScriptTags')->with('app', 'footer', '_default', $this->pageRenderer, ['forceOnTop' => true]);
+        $this->tagRenderer->expects($this->once())->method('renderWebpackScriptTags')->with('app', 'jsFiles', '_default', $this->pageRenderer, ['forceOnTop' => true]);
         $this->tagRenderer->expects($this->once())->method('renderWebpackLinkTags')->with('app', 'all', '_default', $this->pageRenderer);
         $this->subject->renderPreProcess($params, $this->pageRenderer);
     }
@@ -96,7 +96,7 @@ final class PageRendererHooksTest extends UnitTestCase
             ],
         ];
 
-        $this->tagRenderer->expects($this->once())->method('renderWebpackScriptTags')->with('app', '', 'config', $this->pageRenderer);
+        $this->tagRenderer->expects($this->once())->method('renderWebpackScriptTags')->with('app', 'jsFiles', 'config', $this->pageRenderer);
         $this->tagRenderer->expects($this->once())->method('renderWebpackLinkTags')->with('app', 'all', 'config', $this->pageRenderer);
         $this->subject->renderPreProcess($params, $this->pageRenderer);
     }


### PR DESCRIPTION
Hi !

Before this fix, if you placed your `typo3_encore:entry` in `page.includeJSFooterlibs` for example, `TagRenderer` would  call `addJsFooterFile` instead of `addJsFooterLibrary`, which caused some order problems. 

So I just passed the `$includeType` as `$position` parameter in `renderWebpackScriptTags` and added a switch-case to handle this correctly. 
Also flipped some `if`s with early exit to reduce code complexity, but it should not change anything to the behavior.

I also tried to update the tests the best I could, but I'm not really at ease with PHPUnit, so if I did something the wrong way, please let me know. 

Hope this helps !

PS: As you can see in my profile, its the first time I contribute to any project, so please excuse me if I'm not following some best practices or guidelines :)