### PR TITLE
Updated the TagRenderer library handling (update to #50)

### DIFF
--- a/Classes/Asset/TagRendererInterface.php
+++ b/Classes/Asset/TagRendererInterface.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\SingletonInterface;
 
 interface TagRendererInterface extends SingletonInterface
 {
-    public function renderWebpackScriptTags(string $entryName, string $position = 'footer', string $buildName = '_default', PageRenderer $pageRenderer = null, array $parameters = [], bool $registerFile = true);
+    public function renderWebpackScriptTags(string $entryName, string $position = 'footer', string $buildName = '_default', PageRenderer $pageRenderer = null, array $parameters = [], bool $registerFile = true, bool $isLibrary = false);
 
     public function renderWebpackLinkTags(string $entryName, string $media = 'all', string $buildName = '_default', PageRenderer $pageRenderer = null, array $parameters = [], bool $registerFile = true);
 }

--- a/Classes/ViewHelpers/RenderWebpackScriptTagsViewHelper.php
+++ b/Classes/ViewHelpers/RenderWebpackScriptTagsViewHelper.php
@@ -40,10 +40,19 @@ final class RenderWebpackScriptTagsViewHelper extends AbstractViewHelper
         $this->registerArgument('buildName', 'string', 'The build name', false, '_default');
         $this->registerArgument('parameters', 'array', 'Additional parameters for the PageRenderer', false, []);
         $this->registerArgument('registerFile', 'bool', 'Register file for HTTP/2 push functionality', false, true);
+        $this->registerArgument('isLibrary', 'bool', 'Defines if the entry should be loaded as a library (i.e. before other files)', false, false);
     }
 
     public function render(): void
     {
-        $this->tagRenderer->renderWebpackScriptTags($this->arguments['entryName'], $this->arguments['position'], $this->arguments['buildName'], null, $this->arguments['parameters'], $this->arguments['registerFile']);
+        $this->tagRenderer->renderWebpackScriptTags(
+            $this->arguments['entryName'],
+            $this->arguments['position'],
+            $this->arguments['buildName'],
+            null,
+            $this->arguments['parameters'],
+            $this->arguments['registerFile'],
+            $this->arguments['isLibrary']
+        );
     }
 }

--- a/Tests/Unit/Asset/TagRendererTest.php
+++ b/Tests/Unit/Asset/TagRendererTest.php
@@ -88,11 +88,11 @@ final class TagRendererTest extends UnitTestCase
      * @test
      * @dataProvider scriptTagsWithPosition
      */
-    public function renderWebpackScriptTagsWithDefaultBuildInPosition(string $position, string $expectedPageRendererCall): void
+    public function renderWebpackScriptTagsWithDefaultBuildInPosition(string $position, $isLibrary, string $expectedPageRendererCall): void
     {
         $this->entryLookupCollection->getEntrypointLookup('_default')->shouldBeCalledOnce()->willReturn($this->createEntrypointLookUpClass());
 
-        $this->pageRenderer->{$expectedPageRendererCall}(
+        $arguments = [
             'file.js',
             'text/javascript',
             true,
@@ -104,20 +104,26 @@ final class TagRendererTest extends UnitTestCase
             'foobarbaz',
             false,
             ''
-        )->shouldBeCalledOnce();
+        ];
+
+        if ($isLibrary) {
+            array_unshift($arguments, 'file.js');
+        }
+
+        $this->pageRenderer->{$expectedPageRendererCall}(...$arguments)->shouldBeCalledOnce();
 
         $this->assetRegistry->registerFile(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldBeCalledOnce();
-        $this->subject->renderWebpackScriptTags('app', $position, '_default', $this->pageRenderer->reveal(), ['compress' => true, 'excludeFromConcatenation' => false]);
+        $this->subject->renderWebpackScriptTags('app', $position, '_default', $this->pageRenderer->reveal(), ['compress' => true, 'excludeFromConcatenation' => false], true, $isLibrary);
     }
 
     public function scriptTagsWithPosition(): array
     {
         return [
-            ['footer', 'addJsFooterFile'],
-            ['jsFiles', 'addJsFile'],
-            ['jsFooterFiles', 'addJsFooterFile'],
-            ['jsFooterLibs', 'addJsFooterLibrary'],
-            ['jsLibs', 'addJsLibrary'],
+            // $position, $isLibrary, $expectedPageRendererCall
+            ['footer', false, 'addJsFooterFile'],
+            ['footer', true, 'addJsFooterLibrary'],
+            ['', false, 'addJsFile'],
+            ['', true, 'addJsLibrary'],
         ];
     }
 


### PR DESCRIPTION
Hello Sebastian.

First of all, thank you for your quick response and handling on my last PR.

Sorry to have to ask you again, but the last commits did not actually resolve the problem. Indeed, the `renderPreProcess` PageRenderer hook receives all the JS file entries in only `jsFiles` and `jsLibs` and the footer/header information still comes in the `$file['section']` property.

I have made a new fix, which I tested in a 'real world' environment, and everything works now, plus the compatibility is better with the older version, as I reverted the call to `renderWebpackScriptTags` to its initial arguments and only added a new last argument `$isLibrary`, which is subsequently based on the `$includeType` being 'jsLibs' (with a default value, so all calls to this method will still work). Then, I used that to construct the name of the PageRenderer method and handle the `$name` argument, which is required only for libraries.

I also updated the `RenderWebpackScriptTags` ViewHelper with an additional argument so the behavior can be reproduced here too and did some .

Once again, I did my best with unit tests and covering all the possible cases, but if something is still wrong, be sure to let me know :) 

As for the test coverage, I saw that my last PR did have a lower coverage, and this one might too, but I was not able to figure out how to measure it, except by letting the bot build this PR and see the results, so let me know how to handle that and I will fix that too.
