### PR TITLE
Use $_EXTKEY in ext_emconf

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,6 +1,6 @@
 <?php
 
-$EM_CONF['typo3_encore'] = [
+$EM_CONF[$_EXTKEY] = [
     'title' => 'TYPO3 with Webpack Encore',
     'description' => 'Webpack Encore from Symfony for TYPO3',
     'category' => 'fe',


### PR DESCRIPTION
the ext key must not be hardcoded in ext_emconf.
checkout out https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/ExtensionArchitecture/DeclarationFile/Index.html