### PR TITLE
Disable JavaScript type for html5 doctype

### DIFF
--- a/Classes/Asset/TagRenderer.php
+++ b/Classes/Asset/TagRenderer.php
@@ -63,11 +63,16 @@ final class TagRenderer implements TagRendererInterface
         $parameters = array_filter($parameters, static function ($param) {
             return !is_null($param);
         });
+        
+        $type = '';
+        if ($this->getTypoScriptFrontendController()->config['config']['doctype'] !== 'html5') {
+            type = 'text/javascript';
+        }
 
         foreach ($files as $file) {
             $attributes = array_replace([
                 'file' => $this->removeLeadingSlash($file, $parameters) ? ltrim($file, '/') : $file,
-                'type' => 'text/javascript',
+                'type' => $type,
                 'compress' => false,
                 'forceOnTop' => false,
                 'allWrap' => '',


### PR DESCRIPTION
If there is the TypoScript setting config.doctype = html5 we don't want to have the type 'text/javascript' in the script tags.
It works fine via TypoScript including of JS files, but not when using the ViewHelper inside Fluid templates to include scripts.