### PR TITLE
Fixed inclusion of runtime.js at the bottom of the page, if `includeJSLibs` and `includeJSFooter` were used.

### DIFF
--- a/Classes/Asset/TagRendererInterface.php
+++ b/Classes/Asset/TagRendererInterface.php
@@ -18,16 +18,16 @@ interface TagRendererInterface extends SingletonInterface
      * @var array
      */
     public const ALLOWED_CSS_POSITIONS = [
-        'cssFiles',
-        'cssLibs'
+        'cssLibs',
+        'cssFiles'
     ];
 
     /**
      * @var array
      */
     public const ALLOWED_JS_POSITIONS = [
-        'jsFiles',
-        'jsLibs'
+        'jsLibs',
+        'jsFiles'
     ];
 
     /**


### PR DESCRIPTION
Changing the order of allowed positions ensures the libs at the top of the page are processed first.

Fixes #89