### PR TITLE
Fix order for css and js tags.

### DIFF
--- a/Classes/Asset/TagRendererInterface.php
+++ b/Classes/Asset/TagRendererInterface.php
@@ -40,7 +40,11 @@ interface TagRendererInterface extends SingletonInterface
      */
     public const POSITION_JS_LIBRARY = 'jsLibs';
 
+    public function getWebpackScriptTags(string $entryName, string $buildName = EntrypointLookupInterface::DEFAULT_BUILD, array $parameters = [], bool $registerFile = true): array;
+
     public function renderWebpackScriptTags(string $entryName, string $position = 'footer', string $buildName = EntrypointLookupInterface::DEFAULT_BUILD, PageRenderer $pageRenderer = null, array $parameters = [], bool $registerFile = true, bool $isLibrary = false);
+
+    public function getWebpackLinkTags(string $entryName, string $media = 'all', string $buildName = EntrypointLookupInterface::DEFAULT_BUILD, array $parameters = [], bool $registerFile = true): array;
 
     public function renderWebpackLinkTags(string $entryName, string $media = 'all', string $buildName = EntrypointLookupInterface::DEFAULT_BUILD, PageRenderer $pageRenderer = null, array $parameters = [], bool $registerFile = true);
 }

--- a/Classes/Integration/PageRendererHooks.php
+++ b/Classes/Integration/PageRendererHooks.php
@@ -48,11 +48,10 @@ final class PageRendererHooks
                 continue;
             }
 
-            // Is the include type 'jsLibs' and should be treated as a library
-            $isLibrary = $includeType === TagRenderer::POSITION_JS_LIBRARY;
-
+            $includes = [];
             foreach ($params[$includeType] as $key => $jsFile) {
                 if (! $this->isEncoreEntryName($jsFile['file'])) {
+                    $includes[$key] = $jsFile;
                     continue;
                 }
 
@@ -65,12 +64,14 @@ final class PageRendererHooks
                     $entryName = $buildAndEntryName[0];
                 }
 
-                $position = ($jsFile['section'] ?? '') === self::PART_FOOTER ? TagRenderer::POSITION_FOOTER : '';
+                unset($jsFile['file'], $jsFile['integrity']);
 
-                unset($params[$includeType][$key], $jsFile['file'], $jsFile['section'], $jsFile['integrity']);
-
-                $this->tagRenderer->renderWebpackScriptTags($entryName, $position, $buildName, $pageRenderer, $jsFile, true, $isLibrary);
+                $files = $this->tagRenderer->getWebpackScriptTags($entryName, $buildName, $jsFile, true);
+                foreach ($files as $key => $jsFile) {
+                    $includes[$key] = $jsFile;
+                }
             }
+            $params[$includeType] = $includes;
         }
 
         // Add CSS-Files by entryNames
@@ -79,8 +80,10 @@ final class PageRendererHooks
                 continue;
             }
 
+            $includes = [];
             foreach ($params[$includeType] as $key => $cssFile) {
                 if (! $this->isEncoreEntryName($cssFile['file'])) {
+                    $includes[$key] = $cssFile;
                     continue;
                 }
                 $buildAndEntryName = $this->createBuildAndEntryName($cssFile['file']);
@@ -92,10 +95,14 @@ final class PageRendererHooks
                     $entryName = $buildAndEntryName[0];
                 }
 
-                unset($params[$includeType][$key], $cssFile['file']);
+                unset($cssFile['file']);
 
-                $this->tagRenderer->renderWebpackLinkTags($entryName, 'all', $buildName, $pageRenderer, $cssFile);
+                $files = $this->tagRenderer->getWebpackLinkTags($entryName, 'all', $buildName, $cssFile);
+                foreach ($files as $key => $cssFile) {
+                    $includes[$key] = $cssFile;
+                }
             }
+            $params[$includeType] = $includes;
         }
     }
 

--- a/Tests/Unit/Integration/PageRendererHooksTest.php
+++ b/Tests/Unit/Integration/PageRendererHooksTest.php
@@ -70,6 +70,8 @@ final class PageRendererHooksTest extends UnitTestCase
 
         $this->tagRenderer->expects(self::never())->method('renderWebpackScriptTags');
         $this->tagRenderer->expects(self::never())->method('renderWebpackLinkTags');
+        $this->tagRenderer->expects(self::never())->method('getWebpackScriptTags');
+        $this->tagRenderer->expects(self::never())->method('getWebpackLinkTags');
         $this->subject->renderPreProcess($params, $this->pageRenderer);
     }
 
@@ -88,6 +90,8 @@ final class PageRendererHooksTest extends UnitTestCase
 
         $this->tagRenderer->expects(self::never())->method('renderWebpackScriptTags');
         $this->tagRenderer->expects(self::never())->method('renderWebpackLinkTags');
+        $this->tagRenderer->expects(self::never())->method('getWebpackScriptTags');
+        $this->tagRenderer->expects(self::never())->method('getWebpackLinkTags');
         $this->subject->renderPreProcess($params, $this->pageRenderer);
     }
 
@@ -111,8 +115,8 @@ final class PageRendererHooksTest extends UnitTestCase
             ],
         ];
 
-        $this->tagRenderer->expects(self::once())->method('renderWebpackScriptTags')->with('app', 'footer', EntrypointLookupInterface::DEFAULT_BUILD, $this->pageRenderer, ['forceOnTop' => true]);
-        $this->tagRenderer->expects(self::once())->method('renderWebpackLinkTags')->with('app', 'all', EntrypointLookupInterface::DEFAULT_BUILD, $this->pageRenderer);
+        $this->tagRenderer->expects(self::once())->method('getWebpackScriptTags')->with('app', EntrypointLookupInterface::DEFAULT_BUILD, ['forceOnTop' => true, 'section' => 2]);
+        $this->tagRenderer->expects(self::once())->method('getWebpackLinkTags')->with('app', 'all', EntrypointLookupInterface::DEFAULT_BUILD);
         $this->subject->renderPreProcess($params, $this->pageRenderer);
     }
 
@@ -134,8 +138,8 @@ final class PageRendererHooksTest extends UnitTestCase
             ],
         ];
 
-        $this->tagRenderer->expects(self::once())->method('renderWebpackScriptTags')->with('app', '', 'config', $this->pageRenderer);
-        $this->tagRenderer->expects(self::once())->method('renderWebpackLinkTags')->with('app', 'all', 'config', $this->pageRenderer);
+        $this->tagRenderer->expects(self::once())->method('getWebpackScriptTags')->with('app', 'config');
+        $this->tagRenderer->expects(self::once())->method('getWebpackLinkTags')->with('app', 'all', 'config');
         $this->subject->renderPreProcess($params, $this->pageRenderer);
     }
 }


### PR DESCRIPTION
When mixing typo3 encore with normal includes typo3-encore files were always included at the end.
This fixes #88.
TagRendererTest still needs to be fixed.