### PR TITLE
Split up allWrap to wrap all files of an entrypoint

### DIFF
--- a/Classes/Asset/TagRenderer.php
+++ b/Classes/Asset/TagRenderer.php
@@ -59,20 +59,43 @@ final class TagRenderer implements TagRendererInterface
 
         unset($parameters['file']);
 
+        $wrapFirst = '';
+        $wrapLast = '';
+        $fileCount = count($files);
+        if (!empty($parameters['allWrap']) && $fileCount > 1) {
+            // If there are multiple files, allWrap should wrap all.
+            // To do this, it's split up into two parts. The first part wraps the first file
+            // and the second part wraps the last file.
+            $splitChar = !empty($parameters['splitChar']) ? $parameters['splitChar'] : '|';
+            $wrapArr = explode($splitChar, $parameters['allWrap'], 2);
+            $wrapFirst = $wrapArr[0] . $splitChar;
+            $wrapLast = $splitChar . $wrapArr[1];
+            unset($parameters['allWrap']);
+        }
+
         // We do not want to replace null values in $attributes
         $parameters = array_filter($parameters, static function ($param) {
             return !is_null($param);
         });
 
-        foreach ($files as $file) {
+        foreach ($files as $index => $file) {
             $this->addAdditionalAbsRefPrefixDirectories($file);
+
+            $allWrap = '';
+            if (!$index) {
+                // first file
+                $allWrap = $wrapFirst;
+            } elseif ($index === $fileCount - 1) {
+                // last file
+                $allWrap = $wrapLast;
+            }
 
             $attributes = array_replace([
                 'file' => $this->removeLeadingSlash($file, $parameters) ? ltrim($file, '/') : $file,
                 'type' => $this->removeType($parameters) ? '' : 'text/javascript',
                 'compress' => false,
                 'forceOnTop' => false,
-                'allWrap' => '',
+                'allWrap' => $allWrap,
                 'excludeFromConcatenation' => true,
                 'splitChar' => '|',
                 'async' => false,
@@ -108,8 +131,32 @@ final class TagRenderer implements TagRendererInterface
         $files = $entryPointLookup->getCssFiles($entryName);
 
         unset($parameters['file']);
-        foreach ($files as $file) {
+
+        $wrapFirst = '';
+        $wrapLast = '';
+        $fileCount = count($files);
+        if (!empty($parameters['allWrap']) && $fileCount > 1) {
+            // If there are multiple files, allWrap should wrap all.
+            // To do this, it's split up into two parts. The first part wraps the first file
+            // and the second part wraps the last file.
+            $splitChar = !empty($parameters['splitChar']) ? $parameters['splitChar'] : '|';
+            $wrapArr = explode($splitChar, $parameters['allWrap'], 2);
+            $wrapFirst = $wrapArr[0] . $splitChar;
+            $wrapLast = $splitChar . $wrapArr[1];
+            unset($parameters['allWrap']);
+        }
+
+        foreach ($files as $index => $file) {
             $this->addAdditionalAbsRefPrefixDirectories($file);
+
+            $allWrap = '';
+            if (!$index) {
+                // first file
+                $allWrap = $wrapFirst;
+            } elseif ($index === $fileCount - 1) {
+                // last file
+                $allWrap = $wrapLast;
+            }
 
             $attributes = array_replace([
                 'file' => $this->removeLeadingSlash($file, $parameters) ? ltrim($file, '/') : $file,
@@ -118,7 +165,7 @@ final class TagRenderer implements TagRendererInterface
                 'title' => '',
                 'compress' => false,
                 'forceOnTop' => false,
-                'allWrap' => '',
+                'allWrap' => $allWrap,
                 'excludeFromConcatenation' => true,
                 'splitChar' => '|',
                 'inline' => false,

--- a/Tests/Unit/Asset/TagRendererTest.php
+++ b/Tests/Unit/Asset/TagRendererTest.php
@@ -172,6 +172,47 @@ final class TagRendererTest extends UnitTestCase
         $this->subject->renderWebpackLinkTags('app', 'all', EntrypointLookupInterface::DEFAULT_BUILD, $this->pageRenderer->reveal(), ['forceOnTop' => true, 'compress' => true], false);
     }
 
+    /**
+     * Test if an entry point with multiple files wraps all files, if allWrap was supplied
+     * @test
+     */
+    public function renderWebpackScriptTagsWithMultipleFilesAndAllWrap(): void
+    {
+        $this->entryLookupCollection->getEntrypointLookup(EntrypointLookupInterface::DEFAULT_BUILD)->shouldBeCalledOnce()->willReturn($this->createEntrypointLookUpClassWithMultipleEntries());
+
+        $this->pageRenderer->addJsFile(
+            'file1.js',
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            'BEFORE|',
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any()
+        )->shouldBeCalled();
+
+        $this->pageRenderer->addJsFile(
+            'file2.js',
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            '|AFTER',
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any(),
+            Argument::any()
+        )->shouldBeCalled();
+
+        $this->subject->renderWebpackScriptTags('app', 'header', EntrypointLookupInterface::DEFAULT_BUILD, $this->pageRenderer->reveal(), ['compress' => true, 'excludeFromConcatenation' => false, 'allWrap' => 'BEFORE|AFTER']);
+    }
+
     private function addJsFileShouldBeCalledOnce(): void
     {
         $this->pageRenderer->addJsFile(
@@ -211,6 +252,33 @@ final class TagRendererTest extends UnitTestCase
             {
                 return [
                     'file.js' => 'foobarbaz'
+                ];
+            }
+        };
+    }
+
+    private function createEntrypointLookUpClassWithMultipleEntries(): EntrypointLookupInterface
+    {
+        return new class() implements EntrypointLookupInterface, IntegrityDataProviderInterface {
+            public function getJavaScriptFiles(string $entryName): array
+            {
+                return ['file1.js', 'file2.js'];
+            }
+
+            public function getCssFiles(string $entryName): array
+            {
+                return ['file1.css', 'file2.css'];
+            }
+
+            public function reset()
+            {
+            }
+
+            public function getIntegrityData(): array
+            {
+                return [
+                    'file1.js' => 'foobarbaz1',
+                    'file2.js' => 'foobarbaz2',
                 ];
             }
         };


### PR DESCRIPTION
Instead of generating the wrap multiple times, split `allWrap` into two parts.
Wrap the first file with the first part of `allWrap` and wrap the last file with the second part of `allWrap`.

Closes #91