### PR TITLE
Clarify loader configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Install [svg-sprite-loader](https://github.com/kisenka/svg-sprite-loader#install
 const SpritePlugin = require('svg-sprite-loader/plugin');
 
 Encore.addLoader({
-    test: /\.svg$/,
+    test: /\src\/icons\/.svg$/,
     loader: 'svg-sprite-loader',
     options: {
         extract: true,


### PR DESCRIPTION
Assuming the copy files task includes following:
```
pattern: /\.(png|jpg|jpeg|svg)$/
```

... the given sprite loader example may lead to faulty svg file paths. To ease c+p for new users, the `test` property should manifest a distinct folder.