### PR TITLE
Fixed setting of CSS for RTE without buildName.

### DIFF
--- a/Classes/Form/FormDataProvider/RichtextEncoreConfiguration.php
+++ b/Classes/Form/FormDataProvider/RichtextEncoreConfiguration.php
@@ -69,10 +69,6 @@ final class RichtextEncoreConfiguration implements FormDataProviderInterface
                 } else {
                     $entryName = $buildAndEntryName[0];
                 }
-                if ('' !== $entryName) {
-                    $entryName = $buildName;
-                    $buildName = EntrypointLookupInterface::DEFAULT_BUILD;
-                }
 
                 $entryPointLookup = $this->entrypointLookupCollection->getEntrypointLookup($buildName);
                 $cssFiles = $entryPointLookup->getCssFiles($entryName);

--- a/Tests/Unit/Form/FormDataProvider/RichtextEncoreConfigurationTest.php
+++ b/Tests/Unit/Form/FormDataProvider/RichtextEncoreConfigurationTest.php
@@ -29,7 +29,6 @@ final class RichtextEncoreConfigurationTest extends UnitTestCase
 
     /**
      * @dataProvider provideRteConfigurationWithEncoreFiles
-     * @dataProvider provideRteConfigurationWithoutEncoreFiles
      *
      * @param string|string[] $contentsCss
      */
@@ -92,15 +91,18 @@ final class RichtextEncoreConfigurationTest extends UnitTestCase
         return new class() implements EntrypointLookupCollectionInterface {
             public function getEntrypointLookup(string $buildName = null): EntrypointLookupInterface
             {
+                if ($buildName !== '_default') {
+                    throw new \Exception('Invalid buildName in test case', 1645708934);
+                }
                 return new class() implements EntrypointLookupInterface, IntegrityDataProviderInterface {
                     public function getJavaScriptFiles(string $entryName): array
                     {
-                        return ['file.js'];
+                        return $entryName === 'entryPoint' ? ['file.js'] : [];
                     }
 
                     public function getCssFiles(string $entryName): array
                     {
-                        return ['file.css'];
+                        return $entryName === 'entryPoint' ? ['file.css'] : [];
                     }
 
                     public function reset(): void


### PR DESCRIPTION
Setting of CSS for RTE did not work without buildName, because the entryName
was always set to the buildName.
The test cases did not catch this issue because of testing stubs.
Now those test cases check if the correct build- and entry names are
given.

Fixes #131