### PR TITLE
[BUGFIX] Add trailing slash to folders in additionalAbsRefPrefixDirectories

### DIFF
--- a/Classes/Asset/TagRenderer.php
+++ b/Classes/Asset/TagRenderer.php
@@ -211,7 +211,7 @@ final class TagRenderer implements TagRendererInterface
                 true
             );
 
-            $newDir = basename(dirname($file));
+            $newDir = basename(dirname($file)) . '/';
 
             if (false === in_array($newDir, $directories, true)) {
                 $GLOBALS['TYPO3_CONF_VARS']['FE']['additionalAbsRefPrefixDirectories'] .= ',' . $newDir;


### PR DESCRIPTION
If there is no trailing slash, there will be slashes added to classes/data-attributes/etc.
that **begins** with the name of the encore OutputPath (e.g. `.setOutputPath('/build')`).
Fixes #97

```html
<!-- expected result -->
<a href="#" class="building" data-something="buildsomething">...</a>
```

```html
<!-- current result -->
<a href="#" class="/building" data-something="/buildsomething">...</a>
___________________^_________________________^
```

The same behaviour could be validated with different output folders


The description in the "DefaultConfigurationDescription.yaml" says:
```text
Enter additional directories to be prepended with absRefPrefix.
Directories must be comma-separated. TYPO3 already prepends
the following directories: typo3/, typo3temp/, typo3conf/ext/ and
all local storages
```
In my understanding we should add the trailing slash to all paths added to this list.