### PR TITLE
[BUGFIX] Do not crash when the TYPO3 cache is empty and flux is used

### DIFF
--- a/Classes/Asset/EntrypointLookupCollection.php
+++ b/Classes/Asset/EntrypointLookupCollection.php
@@ -15,21 +15,26 @@ use Ssch\Typo3Encore\Integration\EntryLookupFactoryInterface;
 
 class EntrypointLookupCollection implements EntrypointLookupCollectionInterface
 {
+    private EntryLookupFactoryInterface $entryLookupFactory;
+
     /**
      * @var array|EntrypointLookupInterface[]
      */
-    private array $buildEntrypoints;
+    private ?array $buildEntrypoints = null;
 
     private ?string $defaultBuildName;
 
     public function __construct(EntryLookupFactoryInterface $entryLookupFactory, string $defaultBuildName = null)
     {
-        $this->buildEntrypoints = $entryLookupFactory->getCollection();
+        $this->entryLookupFactory = $entryLookupFactory;
         $this->defaultBuildName = $defaultBuildName;
     }
 
     public function getEntrypointLookup(string $buildName = null): EntrypointLookupInterface
     {
+        if ($this->buildEntrypoints === null) {
+            $this->buildEntrypoints = $this->entryLookupFactory->getCollection();
+        }
         if (null === $buildName) {
             if (null === $this->defaultBuildName) {
                 throw new UndefinedBuildException(

--- a/Classes/Integration/AssetRegistry.php
+++ b/Classes/Integration/AssetRegistry.php
@@ -20,9 +20,11 @@ final class AssetRegistry implements AssetRegistryInterface
 
     private array $defaultAttributes = [];
 
+    private SettingsServiceInterface $settingsService;
+
     public function __construct(SettingsServiceInterface $settingsService)
     {
-        $this->defaultAttributes['crossorigin'] = $settingsService->getStringByPath('preload.crossorigin');
+        $this->settingsService = $settingsService;
         $this->reset();
     }
 
@@ -52,6 +54,9 @@ final class AssetRegistry implements AssetRegistryInterface
 
     public function getDefaultAttributes(): array
     {
+        if (count($this->defaultAttributes) === 0) {
+            $this->defaultAttributes['crossorigin'] = $this->settingsService->getStringByPath('preload.crossorigin');
+        }
         return $this->defaultAttributes;
     }
 


### PR DESCRIPTION
When using typo3_encore in combination with flux, an exception occurs when loading a page after freshly clearing all caches:

> The build "_default" is not configured

This happens because with an fully empty cache, TYPO3 needs to re-build the TypoScript configuration.
When flux is used, building the TS array means parsing all content elements, which in turn instantiates <encore:renderWebpackScriptTags> tags in them.

Because of constructor dependency injection,
EntrypointLookupFactory::getCollection() gets called, which fails badly.

After fixing this, the settings are still empty because
- again due to constructor dependency injection - AssetRegistry fetches the (still empty) settings, which get cached in SettingsService. When the empty settings are used later, the build _default is still missing.

Resolves: https://github.com/sabbelasichon/typo3_encore/issues/166