### PR TITLE
Refactored Stimulus ViewHelpers

### DIFF
--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -38,7 +38,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                 'Passing an array as first argument of stimulus_controller() is deprecated.'
             );
 
-            if ($controllerValues !== [] || $controllerClasses !== []) {
+            if ([] !== $controllerValues || [] !== $controllerClasses) {
                 throw new \InvalidArgumentException(
                     'You cannot pass an array to the first and second/third argument of stimulus_controller(): check the documentation.'
                 );
@@ -77,7 +77,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                 'Passing an array as first argument of stimulus_action() is deprecated.'
             );
 
-            if ($actionName !== null || $eventName !== null || $parameters !== []) {
+            if (null !== $actionName || null !== $eventName || [] !== $parameters) {
                 throw new \InvalidArgumentException(
                     'You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.'
                 );
@@ -153,7 +153,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                 'Passing an array as first argument of stimulus_target() is deprecated.'
             );
 
-            if ($targetNames !== null) {
+            if (null !== $targetNames) {
                 throw new \InvalidArgumentException(
                     'You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.'
                 );

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -100,7 +100,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                     }
 
                     foreach ($controllerAction as $event => $action) {
-                        $dto->addAction($controller, $action, \is_string($event) ? $eventName : null);
+                        $dto->addAction($controller, $action, \is_string($event) ? $event : null);
                     }
                 }
             }

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -11,32 +11,179 @@ declare(strict_types=1);
 
 namespace Ssch\Typo3Encore\ViewHelpers\Stimulus;
 
+use Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto\StimulusActionsDto;
+use Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto\StimulusControllersDto;
+use Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto\StimulusTargetsDto;
+
 abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper
 {
     protected $escapeOutput = false;
 
     /**
-     * Normalize a Stimulus controller name into its HTML equivalent (no special character and / becomes --).
-     *
-     * @see https://stimulus.hotwired.dev/reference/controllers
+     * @param string|array $controllerName the Stimulus controller name
+     * @param array $controllerValues array of controller values
+     * @param array $controllerClasses array of controller CSS classes
      */
-    protected function normalizeControllerName(string $str): string
-    {
-        return (string) preg_replace('/^@/', '', str_replace('_', '-', str_replace('/', '--', $str)));
+    public function renderStimulusController(
+        $controllerName,
+        array $controllerValues = [],
+        array $controllerClasses = []
+    ): StimulusControllersDto {
+        $dto = new StimulusControllersDto();
+
+        if (\is_array($controllerName)) {
+            trigger_deprecation(
+                'symfony/webpack-encore-bundle',
+                'v1.15.0',
+                'Passing an array as first argument of stimulus_controller() is deprecated.'
+            );
+
+            if ($controllerValues || $controllerClasses) {
+                throw new \InvalidArgumentException(
+                    'You cannot pass an array to the first and second/third argument of stimulus_controller(): check the documentation.'
+                );
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $controllerValues) {
+                $dto->addController($controllerName, $controllerValues);
+            }
+
+            return $dto;
+        }
+
+        $dto->addController($controllerName, $controllerValues, $controllerClasses);
+
+        return $dto;
     }
 
     /**
-     * Normalize a Stimulus Value API key into its HTML equivalent ("kebab case"). Backport features from
-     * symfony/string.
-     *
-     * @see https://stimulus.hotwired.dev/reference/values
+     * @param string|array $controllerName the Stimulus controller name
+     * @param array $parameters Parameters to pass to the action. Optional.
      */
-    protected function normalizeKeyName(string $str): string
-    {
-        // Adapted from ByteString::camel
-        $str = ucfirst(str_replace(' ', '', ucwords((string) preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $str))));
+    public function renderStimulusAction(
+        $controllerName,
+        string $actionName = null,
+        string $eventName = null,
+        array $parameters = []
+    ): StimulusActionsDto {
+        $dto = new StimulusActionsDto();
 
-        // Adapted from ByteString::snake
-        return strtolower((string) preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1-\2', $str));
+        if (\is_array($controllerName)) {
+            trigger_deprecation(
+                'symfony/webpack-encore-bundle',
+                'v1.15.0',
+                'Passing an array as first argument of stimulus_action() is deprecated.'
+            );
+
+            if ($actionName || $eventName || $parameters) {
+                throw new \InvalidArgumentException(
+                    'You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.'
+                );
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $controllerActions) {
+                if (\is_string($controllerActions)) {
+                    $controllerActions = [[$controllerActions]];
+                }
+
+                foreach ($controllerActions as $possibleEventName => $controllerAction) {
+                    if (\is_string($possibleEventName) && \is_string($controllerAction)) {
+                        $controllerAction = [
+                            $possibleEventName => $controllerAction,
+                        ];
+                    } elseif (\is_string($controllerAction)) {
+                        $controllerAction = [$controllerAction];
+                    }
+
+                    foreach ($controllerAction as $eventName => $actionName) {
+                        $dto->addAction($controllerName, $actionName, \is_string($eventName) ? $eventName : null);
+                    }
+                }
+            }
+
+            return $dto;
+        }
+
+        $dto->addAction($controllerName, $actionName, $eventName, $parameters);
+
+        return $dto;
+    }
+
+    public function appendStimulusController(
+        StimulusControllersDto $dto,
+        string $controllerName,
+        array $controllerValues = [],
+        array $controllerClasses = []
+    ): StimulusControllersDto {
+        $dto->addController($controllerName, $controllerValues, $controllerClasses);
+
+        return $dto;
+    }
+
+    /**
+     * @param array $parameters Parameters to pass to the action. Optional.
+     */
+    public function appendStimulusAction(
+        StimulusActionsDto $dto,
+        string $controllerName,
+        string $actionName,
+        string $eventName = null,
+        array $parameters = []
+    ): StimulusActionsDto {
+        $dto->addAction($controllerName, $actionName, $eventName, $parameters);
+
+        return $dto;
+    }
+
+    /**
+     * @param string|array $controllerName the Stimulus controller name
+     * @param string|null $targetNames The space-separated list of target names if a string is passed to the 1st argument. Optional.
+     */
+    public function renderStimulusTarget($controllerName, string $targetNames = null): StimulusTargetsDto
+    {
+        $dto = new StimulusTargetsDto();
+        if (\is_array($controllerName)) {
+            trigger_deprecation(
+                'symfony/webpack-encore-bundle',
+                'v1.15.0',
+                'Passing an array as first argument of stimulus_target() is deprecated.'
+            );
+
+            if ($targetNames) {
+                throw new \InvalidArgumentException(
+                    'You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.'
+                );
+            }
+
+            $data = $controllerName;
+
+            foreach ($data as $controllerName => $targetNames) {
+                $dto->addTarget($controllerName, $targetNames);
+            }
+
+            return $dto;
+        }
+
+        $dto->addTarget($controllerName, $targetNames);
+
+        return $dto;
+    }
+
+    /**
+     * @param string $controllerName the Stimulus controller name
+     * @param string|null $targetNames The space-separated list of target names if a string is passed to the 1st argument. Optional.
+     */
+    public function appendStimulusTarget(
+        StimulusTargetsDto $dto,
+        string $controllerName,
+        string $targetNames = null
+    ): StimulusTargetsDto {
+        $dto->addTarget($controllerName, $targetNames);
+
+        return $dto;
     }
 }

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -46,8 +46,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
 
             $data = $controllerName;
 
-            foreach ($data as $controllerName => $values) {
-                $dto->addController($controllerName, $values);
+            foreach ($data as $controller => $values) {
+                $dto->addController($controller, $values);
             }
 
             return $dto;
@@ -99,8 +99,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                         $controllerAction = [$controllerAction];
                     }
 
-                    foreach ($controllerAction as $eventName => $action) {
-                        $dto->addAction($controller, $action, \is_string($eventName) ? $eventName : null);
+                    foreach ($controllerAction as $event => $action) {
+                        $dto->addAction($controller, $action, \is_string($event) ? $eventName : null);
                     }
                 }
             }
@@ -108,7 +108,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
             return $dto;
         }
 
-        $dto->addAction($controllerName, $actionName, $eventName, $parameters);
+        $dto->addAction($controllerName, (string) $actionName, $eventName, $parameters);
 
         return $dto;
     }
@@ -153,7 +153,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                 'Passing an array as first argument of stimulus_target() is deprecated.'
             );
 
-            if ($targetNames) {
+            if ($targetNames !== null) {
                 throw new \InvalidArgumentException(
                     'You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.'
                 );
@@ -161,8 +161,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
 
             $data = $controllerName;
 
-            foreach ($data as $controllerName => $targetNames) {
-                $dto->addTarget($controllerName, $targetNames);
+            foreach ($data as $controller => $targets) {
+                $dto->addTarget($controller, $targets);
             }
 
             return $dto;

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -35,7 +35,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
             trigger_deprecation(
                 'symfony/webpack-encore-bundle',
                 'v1.15.0',
-                'Passing an array as first argument of stimulus_controller() is deprecated.'
+                'Passing an array as first argument of stimulus_controller() is deprecated.',
+                E_USER_DEPRECATED
             );
 
             if ([] !== $controllerValues || [] !== $controllerClasses) {

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -74,7 +74,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
             trigger_deprecation(
                 'symfony/webpack-encore-bundle',
                 'v1.15.0',
-                'Passing an array as first argument of stimulus_action() is deprecated.'
+                'Passing an array as first argument of stimulus_action() is deprecated.',
+                E_USER_DEPRECATED
             );
 
             if (null !== $actionName || null !== $eventName || [] !== $parameters) {

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -151,7 +151,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
             trigger_deprecation(
                 'symfony/webpack-encore-bundle',
                 'v1.15.0',
-                'Passing an array as first argument of stimulus_target() is deprecated.'
+                'Passing an array as first argument of stimulus_target() is deprecated.',
+                E_USER_DEPRECATED
             );
 
             if (null !== $targetNames) {

--- a/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/AbstractViewHelper.php
@@ -38,7 +38,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                 'Passing an array as first argument of stimulus_controller() is deprecated.'
             );
 
-            if ($controllerValues || $controllerClasses) {
+            if ($controllerValues !== [] || $controllerClasses !== []) {
                 throw new \InvalidArgumentException(
                     'You cannot pass an array to the first and second/third argument of stimulus_controller(): check the documentation.'
                 );
@@ -46,8 +46,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
 
             $data = $controllerName;
 
-            foreach ($data as $controllerName => $controllerValues) {
-                $dto->addController($controllerName, $controllerValues);
+            foreach ($data as $controllerName => $values) {
+                $dto->addController($controllerName, $values);
             }
 
             return $dto;
@@ -77,7 +77,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                 'Passing an array as first argument of stimulus_action() is deprecated.'
             );
 
-            if ($actionName || $eventName || $parameters) {
+            if ($actionName !== null || $eventName !== null || $parameters !== []) {
                 throw new \InvalidArgumentException(
                     'You cannot pass a string to the second or third argument nor an array to the fourth argument while passing an array to the first argument of stimulus_action(): check the documentation.'
                 );
@@ -85,7 +85,7 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
 
             $data = $controllerName;
 
-            foreach ($data as $controllerName => $controllerActions) {
+            foreach ($data as $controller => $controllerActions) {
                 if (\is_string($controllerActions)) {
                     $controllerActions = [[$controllerActions]];
                 }
@@ -99,8 +99,8 @@ abstract class AbstractViewHelper extends \TYPO3Fluid\Fluid\Core\ViewHelper\Abst
                         $controllerAction = [$controllerAction];
                     }
 
-                    foreach ($controllerAction as $eventName => $actionName) {
-                        $dto->addAction($controllerName, $actionName, \is_string($eventName) ? $eventName : null);
+                    foreach ($controllerAction as $eventName => $action) {
+                        $dto->addAction($controller, $action, \is_string($eventName) ? $eventName : null);
                     }
                 }
             }

--- a/Classes/ViewHelpers/Stimulus/ActionViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/ActionViewHelper.php
@@ -18,12 +18,7 @@ final class ActionViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
     {
-        $this->registerArgument(
-            'controllerName',
-            'string|array',
-            'The Stimulus controller name to render.',
-            true
-        );
+        $this->registerArgument('controllerName', 'string|array', 'The Stimulus controller name to render.', true);
         $this->registerArgument(
             'eventName',
             'string',
@@ -34,13 +29,7 @@ final class ActionViewHelper extends AbstractViewHelper
             'string',
             'The action to trigger if a string is passed to the 1st argument. Optional.'
         );
-        $this->registerArgument(
-            'parameters',
-            'array',
-            'Parameters to pass to the action. Optional.',
-            false,
-            []
-        );
+        $this->registerArgument('parameters', 'array', 'Parameters to pass to the action. Optional.', false, []);
     }
 
     public function render(): string

--- a/Classes/ViewHelpers/Stimulus/ActionViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/ActionViewHelper.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Ssch\Typo3Encore\ViewHelpers\Stimulus;
 
-use InvalidArgumentException;
-
 /**
  * Copyright (c) 2004-2018 Fabien Potencier
  */
@@ -29,73 +27,29 @@ final class ActionViewHelper extends AbstractViewHelper
         $this->registerArgument(
             'eventName',
             'string',
-            'The action to trigger if a string is passed to the 1st argument. Optional.',
-            false
+            'The event to listen to trigger if a string is passed to the 1st argument. Optional.',
         );
         $this->registerArgument(
             'actionName',
             'string',
-            'The event to listen to trigger if a string is passed to the 1st argument. Optional.',
-            false
+            'The action to trigger if a string is passed to the 1st argument. Optional.'
+        );
+        $this->registerArgument(
+            'parameters',
+            'array',
+            'Parameters to pass to the action. Optional.',
+            false,
+            []
         );
     }
 
     public function render(): string
     {
-        $dataOrControllerName = $this->arguments['dataOrControllerName'];
-        $eventName = $this->arguments['eventName'];
-        $actionName = $this->arguments['actionName'];
-
-        if (\is_string($dataOrControllerName)) {
-            $data = [
-                $dataOrControllerName => null === $eventName ? [[$actionName]] : [[
-                    $eventName => $actionName,
-                ]],
-            ];
-        } else {
-            if ($actionName || $eventName) {
-                throw new InvalidArgumentException(
-                    'You cannot pass a string to the second or third argument while passing an array to the first argument of stimulus_action(): check the documentation.'
-                );
-            }
-
-            $data = $dataOrControllerName;
-
-            if (! $data) {
-                return '';
-            }
-        }
-
-        $actions = [];
-
-        foreach ($data as $controllerName => $controllerActions) {
-            $controllerName = $this->normalizeControllerName($controllerName);
-
-            if (\is_string($controllerActions)) {
-                $controllerActions = [[$controllerActions]];
-            }
-
-            foreach ($controllerActions as $possibleEventName => $controllerAction) {
-                if (\is_string($possibleEventName) && \is_string($controllerAction)) {
-                    $controllerAction = [
-                        $possibleEventName => $controllerAction,
-                    ];
-                } elseif (\is_string($controllerAction)) {
-                    $controllerAction = [$controllerAction];
-                }
-
-                foreach ($controllerAction as $internalEventName => $internalActionName) {
-                    $action = $controllerName . '#' . $internalActionName;
-
-                    if (\is_string($internalEventName)) {
-                        $action = $internalEventName . '->' . $action;
-                    }
-
-                    $actions[] = $action;
-                }
-            }
-        }
-
-        return 'data-action="' . implode(' ', $actions) . '"';
+        return $this->renderStimulusAction(
+            $this->arguments['dataOrControllerName'],
+            $this->arguments['actionName'],
+            $this->arguments['eventName'],
+            $this->arguments['parameters']
+        )->__toString();
     }
 }

--- a/Classes/ViewHelpers/Stimulus/ActionViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/ActionViewHelper.php
@@ -19,9 +19,9 @@ final class ActionViewHelper extends AbstractViewHelper
     public function initializeArguments(): void
     {
         $this->registerArgument(
-            'dataOrControllerName',
+            'controllerName',
             'string|array',
-            'This can either be a map of controller names as keys set to their "values". Or this can be a string controller name and data is passed as the 2nd argument.',
+            'The Stimulus controller name to render.',
             true
         );
         $this->registerArgument(
@@ -46,7 +46,7 @@ final class ActionViewHelper extends AbstractViewHelper
     public function render(): string
     {
         return $this->renderStimulusAction(
-            $this->arguments['dataOrControllerName'],
+            $this->arguments['controllerName'],
             $this->arguments['actionName'],
             $this->arguments['eventName'],
             $this->arguments['parameters']

--- a/Classes/ViewHelpers/Stimulus/ControllerViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/ControllerViewHelper.php
@@ -15,12 +15,7 @@ final class ControllerViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
     {
-        $this->registerArgument(
-            'controllerName',
-            'string|array',
-            'The Stimulus controller name to render.',
-            true
-        );
+        $this->registerArgument('controllerName', 'string|array', 'The Stimulus controller name to render.', true);
         $this->registerArgument(
             'controllerValues',
             'array',

--- a/Classes/ViewHelpers/Stimulus/ControllerViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/ControllerViewHelper.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Ssch\Typo3Encore\ViewHelpers\Stimulus;
 
-use InvalidArgumentException;
-
 final class ControllerViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
@@ -30,57 +28,21 @@ final class ControllerViewHelper extends AbstractViewHelper
             false,
             []
         );
+        $this->registerArgument(
+            'controllerClasses',
+            'array',
+            'Array of classes to add to the controller',
+            false,
+            []
+        );
     }
 
     public function render(): string
     {
-        $dataOrControllerName = $this->arguments['dataOrControllerName'];
-        $controllerValues = $this->arguments['controllerValues'];
-
-        if (\is_string($dataOrControllerName)) {
-            $data = [
-                $dataOrControllerName => $controllerValues,
-            ];
-        } else {
-            if ($controllerValues) {
-                throw new InvalidArgumentException(
-                    'You cannot pass an array to the first and second argument of stimulus_controller(): check the documentation.'
-                );
-            }
-
-            $data = $dataOrControllerName;
-
-            if (! $data) {
-                return '';
-            }
-        }
-
-        $controllers = [];
-        $values = [];
-
-        foreach ($data as $controllerName => $controllerValue) {
-            $controllerName = $this->normalizeControllerName($controllerName);
-            $controllers[] = $controllerName;
-
-            foreach ($controllerValue as $key => $value) {
-                if (null === $value) {
-                    continue;
-                }
-
-                if (! is_scalar($value)) {
-                    $value = json_encode($value, JSON_THROW_ON_ERROR);
-                }
-
-                if (\is_bool($value)) {
-                    $value = $value ? 'true' : 'false';
-                }
-
-                $key = $this->normalizeKeyName($key);
-
-                $values[] = 'data-' . $controllerName . '-' . $key . '-value="' . $value . '"';
-            }
-        }
-
-        return rtrim('data-controller="' . implode(' ', $controllers) . '" ' . implode(' ', $values));
+        return $this->renderStimulusController(
+            $this->arguments['dataOrControllerName'],
+            $this->arguments['controllerValues'],
+            $this->arguments['controllerClasses']
+        )->__toString();
     }
 }

--- a/Classes/ViewHelpers/Stimulus/ControllerViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/ControllerViewHelper.php
@@ -16,9 +16,9 @@ final class ControllerViewHelper extends AbstractViewHelper
     public function initializeArguments(): void
     {
         $this->registerArgument(
-            'dataOrControllerName',
+            'controllerName',
             'string|array',
-            'This can either be a map of controller names as keys set to their "values". Or this can be a string controller name and data is passed as the 2nd argument.',
+            'The Stimulus controller name to render.',
             true
         );
         $this->registerArgument(
@@ -40,7 +40,7 @@ final class ControllerViewHelper extends AbstractViewHelper
     public function render(): string
     {
         return $this->renderStimulusController(
-            $this->arguments['dataOrControllerName'],
+            $this->arguments['controllerName'],
             $this->arguments['controllerValues'],
             $this->arguments['controllerClasses']
         )->__toString();

--- a/Classes/ViewHelpers/Stimulus/Dto/AbstractStimulusDto.php
+++ b/Classes/ViewHelpers/Stimulus/Dto/AbstractStimulusDto.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_encore" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto;
+
+abstract class AbstractStimulusDto
+{
+    abstract public function toArray(): array;
+
+    protected function getFormattedControllerName(string $controllerName): string
+    {
+        return $this->escapeAsHtmlAttr($this->normalizeControllerName($controllerName));
+    }
+
+    protected function getFormattedValue($value)
+    {
+        if ((\is_object($value) && \is_callable([$value, '__toString']))) {
+            $value = (string) $value;
+        } elseif (! \is_scalar($value)) {
+            $value = json_encode($value);
+        } elseif (\is_bool($value)) {
+            $value = $value ? 'true' : 'false';
+        }
+
+        return (string) $value;
+    }
+
+    protected function escapeAsHtmlAttr($value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES);
+    }
+
+    /**
+     * Normalize a Stimulus controller name into its HTML equivalent (no special character and / becomes --).
+     *
+     * @see https://stimulus.hotwired.dev/reference/controllers
+     */
+    private function normalizeControllerName(string $controllerName): string
+    {
+        return preg_replace('/^@/', '', str_replace('_', '-', str_replace('/', '--', $controllerName)));
+    }
+}

--- a/Classes/ViewHelpers/Stimulus/Dto/AbstractStimulusDto.php
+++ b/Classes/ViewHelpers/Stimulus/Dto/AbstractStimulusDto.php
@@ -20,7 +20,10 @@ abstract class AbstractStimulusDto
         return $this->escapeAsHtmlAttr($this->normalizeControllerName($controllerName));
     }
 
-    protected function getFormattedValue($value)
+    /**
+     * @param mixed $value
+     */
+    protected function getFormattedValue($value): string
     {
         if ((\is_object($value) && \is_callable([$value, '__toString']))) {
             $value = (string) $value;
@@ -33,7 +36,7 @@ abstract class AbstractStimulusDto
         return (string) $value;
     }
 
-    protected function escapeAsHtmlAttr($value): string
+    protected function escapeAsHtmlAttr(string $value): string
     {
         return htmlspecialchars($value, ENT_QUOTES);
     }
@@ -45,6 +48,6 @@ abstract class AbstractStimulusDto
      */
     private function normalizeControllerName(string $controllerName): string
     {
-        return preg_replace('/^@/', '', str_replace('_', '-', str_replace('/', '--', $controllerName)));
+        return (string) preg_replace('/^@/', '', str_replace('_', '-', str_replace('/', '--', $controllerName)));
     }
 }

--- a/Classes/ViewHelpers/Stimulus/Dto/StimulusActionsDto.php
+++ b/Classes/ViewHelpers/Stimulus/Dto/StimulusActionsDto.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_encore" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto;
+
+final class StimulusActionsDto extends AbstractStimulusDto
+{
+    private array $actions = [];
+
+    private array $parameters = [];
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->actions)) {
+            return '';
+        }
+
+        return rtrim(
+            'data-action="' . implode(' ', $this->actions) . '" ' . implode(' ', array_map(
+                function (string $attribute, string $value): string {
+                    return $attribute . '="' . $this->escapeAsHtmlAttr($value) . '"';
+                },
+                array_keys($this->parameters),
+                $this->parameters
+            ))
+        );
+    }
+
+    /**
+     * @param array $parameters Parameters to pass to the action. Optional.
+     */
+    public function addAction(
+        string $controllerName,
+        string $actionName,
+        string $eventName = null,
+        array $parameters = []
+    ): void {
+        $controllerName = $this->getFormattedControllerName($controllerName);
+        $action = $controllerName . '#' . $this->escapeAsHtmlAttr($actionName);
+
+        if (null !== $eventName) {
+            $action = $eventName . '->' . $action;
+        }
+
+        $this->actions[] = $action;
+
+        foreach ($parameters as $name => $value) {
+            $this->parameters['data-' . $controllerName . '-' . $name . '-param'] = $this->getFormattedValue($value);
+        }
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'data-action' => implode(' ', $this->actions),
+        ] + $this->parameters;
+    }
+}

--- a/Classes/ViewHelpers/Stimulus/Dto/StimulusControllersDto.php
+++ b/Classes/ViewHelpers/Stimulus/Dto/StimulusControllersDto.php
@@ -77,9 +77,9 @@ class StimulusControllersDto extends AbstractStimulusDto
     private function normalizeKeyName(string $str): string
     {
         // Adapted from ByteString::camel
-        $str = ucfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $str))));
+        $str = ucfirst(str_replace(' ', '', ucwords((string) preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $str))));
 
         // Adapted from ByteString::snake
-        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1-\2', $str));
+        return strtolower((string) preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1-\2', $str));
     }
 }

--- a/Classes/ViewHelpers/Stimulus/Dto/StimulusControllersDto.php
+++ b/Classes/ViewHelpers/Stimulus/Dto/StimulusControllersDto.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_encore" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto;
+
+class StimulusControllersDto extends AbstractStimulusDto
+{
+    private array $controllers = [];
+
+    private array $values = [];
+
+    private array $classes = [];
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->controllers)) {
+            return '';
+        }
+
+        return rtrim(
+            'data-controller="' . implode(' ', $this->controllers) . '" ' .
+            implode(' ', array_map(function (string $attribute, string $value): string {
+                return $attribute . '="' . $this->escapeAsHtmlAttr($value) . '"';
+            }, array_keys($this->values), $this->values)) . ' ' .
+            implode(' ', array_map(function (string $attribute, string $value): string {
+                return $attribute . '="' . $this->escapeAsHtmlAttr($value) . '"';
+            }, array_keys($this->classes), $this->classes))
+        );
+    }
+
+    public function addController(
+        string $controllerName,
+        array $controllerValues = [],
+        array $controllerClasses = []
+    ): void {
+        $controllerName = $this->getFormattedControllerName($controllerName);
+
+        $this->controllers[] = $controllerName;
+
+        foreach ($controllerValues as $key => $value) {
+            if (null === $value) {
+                continue;
+            }
+
+            $key = $this->escapeAsHtmlAttr($this->normalizeKeyName($key));
+            $value = $this->getFormattedValue($value);
+
+            $this->values['data-' . $controllerName . '-' . $key . '-value'] = $value;
+        }
+
+        foreach ($controllerClasses as $key => $class) {
+            $key = $this->escapeAsHtmlAttr($this->normalizeKeyName($key));
+
+            $this->values['data-' . $controllerName . '-' . $key . '-class'] = $class;
+        }
+    }
+
+    public function toArray(): array
+    {
+        if (0 === \count($this->controllers)) {
+            return [];
+        }
+
+        return [
+            'data-controller' => implode(' ', $this->controllers),
+        ] + $this->values + $this->classes;
+    }
+
+    private function normalizeKeyName(string $str): string
+    {
+        // Adapted from ByteString::camel
+        $str = ucfirst(str_replace(' ', '', ucwords(preg_replace('/[^a-zA-Z0-9\x7f-\xff]++/', ' ', $str))));
+
+        // Adapted from ByteString::snake
+        return strtolower(preg_replace(['/([A-Z]+)([A-Z][a-z])/', '/([a-z\d])([A-Z])/'], '\1-\2', $str));
+    }
+}

--- a/Classes/ViewHelpers/Stimulus/Dto/StimulusTargetsDto.php
+++ b/Classes/ViewHelpers/Stimulus/Dto/StimulusTargetsDto.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the "typo3_encore" Extension for TYPO3 CMS.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ */
+
+namespace Ssch\Typo3Encore\ViewHelpers\Stimulus\Dto;
+
+final class StimulusTargetsDto extends AbstractStimulusDto
+{
+    private array $targets = [];
+
+    public function __toString(): string
+    {
+        if (0 === \count($this->targets)) {
+            return '';
+        }
+
+        return implode(' ', array_map(function (string $attribute, string $value): string {
+            return $attribute . '="' . $this->escapeAsHtmlAttr($value) . '"';
+        }, array_keys($this->targets), $this->targets));
+    }
+
+    /**
+     * @param string      $controllerName the Stimulus controller name
+     * @param string|null $targetNames    The space-separated list of target names if a string is passed to the 1st argument. Optional.
+     */
+    public function addTarget(string $controllerName, string $targetNames = null): void
+    {
+        $controllerName = $this->getFormattedControllerName($controllerName);
+
+        $this->targets['data-' . $controllerName . '-target'] = $targetNames;
+    }
+
+    public function toArray(): array
+    {
+        return $this->targets;
+    }
+}

--- a/Classes/ViewHelpers/Stimulus/TargetViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/TargetViewHelper.php
@@ -18,12 +18,7 @@ final class TargetViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
     {
-        $this->registerArgument(
-            'controllerName',
-            'string|array',
-            'The Stimulus controller name to render.',
-            true
-        );
+        $this->registerArgument('controllerName', 'string|array', 'The Stimulus controller name to render.', true);
         $this->registerArgument(
             'targetNames',
             'string',

--- a/Classes/ViewHelpers/Stimulus/TargetViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/TargetViewHelper.php
@@ -11,8 +11,6 @@ declare(strict_types=1);
 
 namespace Ssch\Typo3Encore\ViewHelpers\Stimulus;
 
-use InvalidArgumentException;
-
 /**
  * Copyright (c) 2004-2018 Fabien Potencier
  */
@@ -30,47 +28,14 @@ final class TargetViewHelper extends AbstractViewHelper
             'targetNames',
             'string',
             'The space-separated list of target names if a string is passed to the 1st argument. Optional.',
-            false
         );
     }
 
     public function render(): string
     {
-        $dataOrControllerName = $this->arguments['dataOrControllerName'];
-        $targetNames = $this->arguments['targetNames'];
-        if (\is_string($dataOrControllerName)) {
-            $data = [
-                $dataOrControllerName => $targetNames,
-            ];
-        } else {
-            if ($targetNames) {
-                throw new InvalidArgumentException(
-                    'You cannot pass a string to the second argument while passing an array to the first argument of stimulus_target(): check the documentation.'
-                );
-            }
-
-            $data = $dataOrControllerName;
-
-            if (! $data) {
-                return '';
-            }
-        }
-
-        $targets = [];
-
-        foreach ($data as $controllerName => $targetName) {
-            $controllerName = $this->normalizeControllerName($controllerName);
-
-            $targets['data-' . $controllerName . '-target'] = $targetName;
-        }
-
-        return implode(
-            ' ',
-            array_map(
-                static fn (string $attribute, string $value): string => $attribute . '="' . $value . '"',
-                array_keys($targets),
-                $targets
-            )
-        );
+        return $this->renderStimulusTarget(
+            $this->arguments['dataOrControllerName'],
+            $this->arguments['targetNames']
+        )->__toString();
     }
 }

--- a/Classes/ViewHelpers/Stimulus/TargetViewHelper.php
+++ b/Classes/ViewHelpers/Stimulus/TargetViewHelper.php
@@ -19,9 +19,9 @@ final class TargetViewHelper extends AbstractViewHelper
     public function initializeArguments(): void
     {
         $this->registerArgument(
-            'dataOrControllerName',
+            'controllerName',
             'string|array',
-            'This can either be a map of controller names as keys set to their "values". Or this can be a string controller name and data is passed as the 2nd argument.',
+            'The Stimulus controller name to render.',
             true
         );
         $this->registerArgument(
@@ -34,7 +34,7 @@ final class TargetViewHelper extends AbstractViewHelper
     public function render(): string
     {
         return $this->renderStimulusTarget(
-            $this->arguments['dataOrControllerName'],
+            $this->arguments['controllerName'],
             $this->arguments['targetNames']
         )->__toString();
     }

--- a/Tests/Functional/ViewHelpers/Stimulus/ActionViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Stimulus/ActionViewHelperTest.php
@@ -29,17 +29,17 @@ final class ActionViewHelperTest extends FunctionalTestCase
     }
 
     /**
-     * @param array|string $dataOrControllerName
+     * @param array|string $controllerName
      * @dataProvider provideRenderStimulusAction
      */
     public function testRenderData(
-        $dataOrControllerName,
+        $controllerName,
         ?string $actionName,
         ?string $eventName,
         string $expected
     ): void {
         $this->view->assignMultiple([
-            'dataOrControllerName' => $dataOrControllerName,
+            'controllerName' => $controllerName,
             'actionName' => $actionName,
             'eventName' => $eventName,
         ]);
@@ -47,7 +47,7 @@ final class ActionViewHelperTest extends FunctionalTestCase
             ->getViewHelperResolver()
             ->addNamespace('encore', 'Ssch\\Typo3Encore\\ViewHelpers');
         $this->view->setTemplateSource(
-            '{encore:stimulus.action(actionName: actionName, eventName: eventName, dataOrControllerName: dataOrControllerName)}'
+            '{encore:stimulus.action(actionName: actionName, eventName: eventName, controllerName: controllerName)}'
         );
         self::assertSame($expected, $this->view->render());
     }
@@ -55,21 +55,21 @@ final class ActionViewHelperTest extends FunctionalTestCase
     public function provideRenderStimulusAction(): Generator
     {
         yield 'with default event' => [
-            'dataOrControllerName' => 'my-controller',
+            'controllerName' => 'my-controller',
             'actionName' => 'onClick',
             'eventName' => null,
             'expected' => 'data-action="my-controller#onClick"',
         ];
 
         yield 'with custom event' => [
-            'dataOrControllerName' => 'my-controller',
+            'controllerName' => 'my-controller',
             'actionName' => 'onClick',
             'eventName' => 'click',
             'expected' => 'data-action="click->my-controller#onClick"',
         ];
 
         yield 'multiple actions, with default event' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => 'onClick',
                 'my-second-controller' => ['onClick', 'onSomethingElse'],
                 'foo/bar-controller' => 'onClick',
@@ -80,7 +80,7 @@ final class ActionViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'multiple actions, with custom event' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [
                     'click' => 'onClick',
                 ],
@@ -104,7 +104,7 @@ final class ActionViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'multiple actions, with default and custom event' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [
                     'click' => 'onClick',
                 ],
@@ -130,14 +130,14 @@ final class ActionViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'normalize-name, with default event' => [
-            'dataOrControllerName' => '@symfony/ux-dropzone/dropzone',
+            'controllerName' => '@symfony/ux-dropzone/dropzone',
             'actionName' => 'onClick',
             'eventName' => null,
             'expected' => 'data-action="symfony--ux-dropzone--dropzone#onClick"',
         ];
 
         yield 'normalize-name, with custom event' => [
-            'dataOrControllerName' => '@symfony/ux-dropzone/dropzone',
+            'controllerName' => '@symfony/ux-dropzone/dropzone',
             'actionName' => 'onClick',
             'eventName' => 'click',
             'expected' => 'data-action="click->symfony--ux-dropzone--dropzone#onClick"',

--- a/Tests/Functional/ViewHelpers/Stimulus/ControllerViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Stimulus/ControllerViewHelperTest.php
@@ -29,20 +29,20 @@ final class ControllerViewHelperTest extends FunctionalTestCase
     }
 
     /**
-     * @param mixed $dataOrControllerName
+     * @param mixed $controllerName
      * @dataProvider provideRenderStimulusController
      */
-    public function testRenderData($dataOrControllerName, array $controllerValues, string $expected): void
+    public function testRenderData($controllerName, array $controllerValues, string $expected): void
     {
         $this->view->assignMultiple([
-            'dataOrControllerName' => $dataOrControllerName,
+            'controllerName' => $controllerName,
             'controllerValues' => $controllerValues,
         ]);
         $this->view->getRenderingContext()
             ->getViewHelperResolver()
             ->addNamespace('encore', 'Ssch\\Typo3Encore\\ViewHelpers');
         $this->view->setTemplateSource(
-            '{encore:stimulus.controller(dataOrControllerName: dataOrControllerName, controllerValues: controllerValues)}'
+            '{encore:stimulus.controller(controllerName: controllerName, controllerValues: controllerValues)}'
         );
         self::assertSame($expected, $this->view->render());
     }
@@ -50,13 +50,13 @@ final class ControllerViewHelperTest extends FunctionalTestCase
     public function provideRenderStimulusController(): Generator
     {
         yield 'empty' => [
-            'dataOrControllerName' => [],
+            'controllerName' => [],
             'controllerValues' => [],
             'expected' => '',
         ];
 
         yield 'single-controller-no-data' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [],
             ],
             'controllerValues' => [],
@@ -64,7 +64,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'single-controller-scalar-data' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [
                     'myValue' => 'scalar-value',
                 ],
@@ -74,7 +74,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'single-controller-typed-data' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [
                     'boolean' => true,
                     'number' => 4,
@@ -86,7 +86,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'single-controller-nested-data' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [
                     'myValue' => [
                         'nested' => 'array',
@@ -99,7 +99,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'multiple-controllers-scalar-data' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => [
                     'myValue' => 'scalar-value',
                 ],
@@ -112,7 +112,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'normalize-names' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 '@symfony/ux-dropzone/dropzone' => [
                     'my"Key"' => true,
                 ],
@@ -122,13 +122,13 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'short-single-controller-no-data' => [
-            'dataOrControllerName' => 'my-controller',
+            'controllerName' => 'my-controller',
             'controllerValues' => [],
             'expected' => 'data-controller="my-controller"',
         ];
 
         yield 'short-single-controller-with-data' => [
-            'dataOrControllerName' => 'my-controller',
+            'controllerName' => 'my-controller',
             'controllerValues' => [
                 'myValue' => 'scalar-value',
             ],
@@ -136,7 +136,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'false-attribute-value-renders-false' => [
-            'dataOrControllerName' => 'false-controller',
+            'controllerName' => 'false-controller',
             'controllerValues' => [
                 'isEnabled' => false,
             ],
@@ -144,7 +144,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'true-attribute-value-renders-true' => [
-            'dataOrControllerName' => 'true-controller',
+            'controllerName' => 'true-controller',
             'controllerValues' => [
                 'isEnabled' => true,
             ],
@@ -152,7 +152,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
         ];
 
         yield 'null-attribute-value-does-not-render' => [
-            'dataOrControllerName' => 'null-controller',
+            'controllerName' => 'null-controller',
             'controllerValues' => [
                 'firstName' => null,
             ],

--- a/Tests/Functional/ViewHelpers/Stimulus/ControllerViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Stimulus/ControllerViewHelperTest.php
@@ -95,7 +95,7 @@ final class ControllerViewHelperTest extends FunctionalTestCase
             ],
             'controllerValues' => [],
             'expected' =>
-'data-controller="my-controller" data-my-controller-my-value-value="{"nested":"array"}"',
+'data-controller="my-controller" data-my-controller-my-value-value="{&quot;nested&quot;:&quot;array&quot;}"',
         ];
 
         yield 'multiple-controllers-scalar-data' => [

--- a/Tests/Functional/ViewHelpers/Stimulus/TargetViewHelperTest.php
+++ b/Tests/Functional/ViewHelpers/Stimulus/TargetViewHelperTest.php
@@ -29,20 +29,20 @@ final class TargetViewHelperTest extends FunctionalTestCase
     }
 
     /**
-     * @param mixed $dataOrControllerName
+     * @param mixed $controllerName
      * @dataProvider provideRenderStimulusTarget
      */
-    public function testRenderData($dataOrControllerName, ?string $targetName, string $expected): void
+    public function testRenderData($controllerName, ?string $targetName, string $expected): void
     {
         $this->view->assignMultiple([
-            'dataOrControllerName' => $dataOrControllerName,
+            'controllerName' => $controllerName,
             'targetNames' => $targetName,
         ]);
         $this->view->getRenderingContext()
             ->getViewHelperResolver()
             ->addNamespace('encore', 'Ssch\\Typo3Encore\\ViewHelpers');
         $this->view->setTemplateSource(
-            '{encore:stimulus.target(dataOrControllerName: dataOrControllerName, targetNames: targetNames)}'
+            '{encore:stimulus.target(controllerName: controllerName, targetNames: targetNames)}'
         );
         self::assertSame($expected, $this->view->render());
     }
@@ -50,19 +50,19 @@ final class TargetViewHelperTest extends FunctionalTestCase
     public function provideRenderStimulusTarget(): Generator
     {
         yield 'simple' => [
-            'dataOrControllerName' => 'my-controller',
+            'controllerName' => 'my-controller',
             'targetName' => 'myTarget',
             'expected' => 'data-my-controller-target="myTarget"',
         ];
 
         yield 'normalize-name' => [
-            'dataOrControllerName' => '@symfony/ux-dropzone/dropzone',
+            'controllerName' => '@symfony/ux-dropzone/dropzone',
             'targetName' => 'myTarget',
             'expected' => 'data-symfony--ux-dropzone--dropzone-target="myTarget"',
         ];
 
         yield 'multiple' => [
-            'dataOrControllerName' => [
+            'controllerName' => [
                 'my-controller' => 'myTarget',
                 '@symfony/ux-dropzone/dropzone' => 'anotherTarget fooTarget',
             ],


### PR DESCRIPTION
See Issue: #188 

Refactored Stimulus ViewHelpers to streamline their inner workings with the way symfony/webpack-encore-bundle's twig functions work.

This enables seamless TYPO3 integrations for e.g. [Symfony UX](https://ux.symfony.com) packages to easily widen the TYPO3-Symfony-compatibilty.

This PR does not contain any BC Breaks **BUT** I would suggest renaming the `dataOrControllerName` viewhelper argument to `controllerName` since...

1) passing an array as first argument is deprecated since webpack-encore-bundle v1.15
2) The argument is also called `controllerName` there

Renaming the argument would introduce a BC Break.
IMO it's worth it and a quick and easy migration (search-and-replace) for everyone already using the Stimulus ViewHelpers.

What do you think? :)